### PR TITLE
Removed imports missing in Realm 10.37.0 and newer.

### DIFF
--- a/DTModelStorage.podspec
+++ b/DTModelStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'DTModelStorage'
-  s.version      = "11.0.0"
+  s.version      = "11.0.1"
   s.license  = 'MIT'
   s.summary  = 'Storage classes for datasource based controls.'
   s.homepage = 'https://github.com/DenTelezhkin/DTModelStorage'

--- a/DTModelStorage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DTModelStorage.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-cocoa",
       "state" : {
-        "revision" : "fd279e0a94b46c5bd65b17e36817a4365c7a5482",
-        "version" : "10.28.2"
+        "revision" : "71bddc82c4fe3dd6488739ff8b7e99f69183a614",
+        "version" : "10.38.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core",
       "state" : {
-        "revision" : "55a48c287b5e3a8ca129c257ec7e3b92bcb2a05f",
-        "version" : "12.3.0"
+        "revision" : "e56380f05793998dfea0d87a34b68fdba475961c",
+        "version" : "13.9.0"
       }
     }
   ],

--- a/Sources/RealmStorage/RealmSection.swift
+++ b/Sources/RealmStorage/RealmSection.swift
@@ -27,7 +27,6 @@
 import Foundation
 import DTModelStorage
 #if canImport(RealmSwift)
-import Realm.RLMResults
 import RealmSwift
 #else
 // swiftlint:disable:next line_length

--- a/Sources/RealmStorage/RealmStorage.swift
+++ b/Sources/RealmStorage/RealmStorage.swift
@@ -27,7 +27,6 @@
 import Foundation
 import DTModelStorage
 #if canImport(RealmSwift)
-import Realm.RLMResults
 import RealmSwift
 #else
 // swiftlint:disable:next line_length


### PR DESCRIPTION
It looks like something changed in Realm since 10.37.0 release that causes DTModelStorage compilation failure due to missing imports. As far as I tested the removal of that imports does not break the compatibility with releases older than 10.37.0.
<img width="870" alt="Screenshot" src="https://user-images.githubusercontent.com/8874275/230732643-7de20d0e-44a3-49fb-98b8-c4512a6c6b08.png">
